### PR TITLE
WEBUI-637: remove ImageMagick policies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ RUN apt-get install -yq openjdk-$JDK_VERSION-jdk-headless \
   ghostscript \
   exiftool
 
+# remove policies that prevent PDF converters to work
+RUN sed -i '/disable ghostscript format types/,+6d' /etc/ImageMagick-6/policy.xml
+
 # set default JAVA_HOME
 RUN echo 'export JAVA_HOME=$(readlink -f `which javac` | sed "s:/bin/javac::")/bin/java' >> ~/.bashrc
 


### PR DESCRIPTION
Based on the discuss found [here](https://stackoverflow.com/questions/52998331/imagemagick-security-policy-pdf-blocking-conversion) it seems that this solves the problem with the functional tests that required conversion. 