### PR TITLE
NXBT-3589: set grace period to one hour

### DIFF
--- a/charts/runner/templates/deployment.yaml
+++ b/charts/runner/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
     spec:
+      terminationGracePeriodSeconds: 3600
       containers:
         - name: runner
           image: "{{ .Values.runner.image.repository }}:{{ .Values.runner.image.tag }}"


### PR DESCRIPTION
Not the best solution, but a simple one that will allow any pending task to finish before terminating the POD (in average, runs take something between 40-50 minutes).
