### PR TITLE
Update maxReplicas count for Horizontal Pod Autoscaler.

### DIFF
--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -1,6 +1,6 @@
 autoscaling:
   minReplicas: 2
-  maxReplicas: 6
+  maxReplicas: 12
   resource:
     type: cpu
     targetAverageUtilization: 25


### PR DESCRIPTION
Web-ui team is facing issue where github workflow stuck in Queued state for a very long time causing delay in their work. This PR will update the Github runner maxReplicas from 6 to 12 pods when CPU utilization exceeds 25%